### PR TITLE
template index fix

### DIFF
--- a/template-index.yaml
+++ b/template-index.yaml
@@ -6,10 +6,10 @@ metadata:
 spec:
   type: url
   targets:
-    - https://github.com/contract-first-idp/software-templates/blob/main/templates/system/template.yaml
-    - https://github.com/contract-first-idp/software-templates/blob/main/templates/api-specification/template.yaml
-    - https://github.com/contract-first-idp/software-templates/blob/main/templates/quarkus-camel-api-consumer/template.yaml
-    - https://github.com/contract-first-idp/software-templates/blob/main/templates/spring-boot-api-consumer/template.yaml
-    - https://github.com/contract-first-idp/software-templates/blob/main/templates/spring-boot-api-producer/template.yaml
-    - https://github.com/contract-first-idp/software-templates/blob/main/templates/spring-boot-camel-api-consumer/template.yaml
-    - https://github.com/contract-first-idp/software-templates/blob/main/templates/spring-boot-camel-api-producer/template.yaml
+    - https://github.com/agiertli/software-templates/blob/main/templates/system/template.yaml
+    - https://github.com/agiertli/software-templates/blob/main/templates/api-specification/template.yaml
+    - https://github.com/agiertli/software-templates/blob/main/templates/quarkus-camel-api-producer/template.yaml
+    - https://github.com/agiertli/software-templates/blob/main/templates/spring-boot-api-consumer/template.yaml
+    - https://github.com/agiertli/software-templates/blob/main/templates/spring-boot-api-producer/template.yaml
+    - https://github.com/agiertli/software-templates/blob/main/templates/spring-boot-camel-api-consumer/template.yaml
+    - https://github.com/agiertli/software-templates/blob/main/templates/spring-boot-camel-api-producer/template.yaml


### PR DESCRIPTION
There was a 404 in the index preventing the entity from being processed. This was a result of a template rename that wasn't reflected in the index.

But additionally, if you want to play with your own template forks, the index file should point to them.